### PR TITLE
fix: #20200207 部分未登录用户点击加入课程无相应

### DIFF
--- a/src/AppBundle/Controller/BuyFlowController.php
+++ b/src/AppBundle/Controller/BuyFlowController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Common\Exception\AccessDeniedException;
 use AppBundle\Common\UserToolkit;
 use AppBundle\Util\AvatarAlert;
 use Biz\System\Service\SettingService;
@@ -111,7 +112,7 @@ abstract class BuyFlowController extends BaseController
         $user = $this->getCurrentUser();
 
         if (!$user->isLogin()) {
-            $this->createNewException(UserException::UN_LOGIN());
+            throw new AccessDeniedException(UserException::UN_LOGIN());
         }
     }
 


### PR DESCRIPTION
场景：部分Nginx环境用户
描述：未登录状态下点击加入课程出现500错误提示，没有登录模态框弹出