### PR TITLE
fix: #20200212 已创建课时不允许修改班型

### DIFF
--- a/web/activities/live/resources/views/create_or_update_body.html.twig
+++ b/web/activities/live/resources/views/create_or_update_body.html.twig
@@ -24,7 +24,7 @@
       </div>
 
       {% set roomTypes = get_live_room_type() %}
-      {% if roomTypes %}
+      {% if roomTypes and not activity.id|default(false) %}
         <div class="form-group">
           <div class="col-sm-2 control-label">
             <label for="roomType">{{ 'course.live_activity.room_type'|trans }}</label>


### PR DESCRIPTION
因已创建的课时无法修改班型，故屏蔽对应的代码